### PR TITLE
Add deps to be able to build the whole image

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -10,8 +10,9 @@ RUN apt-get update
 RUN apt-get install -y crossbuild-essential-armhf
 
 # perpare build dependencies
-RUN apt-get install -y sudo git fakeroot devscripts cmake vim qemu-user-static binfmt-support dh-make dh-exec \
-	pkg-kde-tools
+RUN apt-get update && apt-get install -y \
+	sudo git fakeroot devscripts cmake vim qemu-user-static binfmt-support dh-make dh-exec \
+	pkg-kde-tools device-tree-compiler bc cpio parted dosfstools mtools libssl-dev
 
 RUN apt-get build-dep -y -a armhf libdrm
 RUN apt-get build-dep -y -a armhf xorg-server

--- a/dockerfile
+++ b/dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update
 RUN apt-get install -y crossbuild-essential-armhf
 
 # perpare build dependencies
-RUN apt-get update && apt-get install -y \
+RUN apt-get install -y \
 	sudo git fakeroot devscripts cmake vim qemu-user-static binfmt-support dh-make dh-exec \
 	pkg-kde-tools device-tree-compiler bc cpio parted dosfstools mtools libssl-dev
 


### PR DESCRIPTION
device-tree-compiler is needed for the kernel to build the dtb
bc is needed by the kernel's build
libssl-dev is needed for make xxxconfig in kernel

parted/dosfstools/mtools is used by mk-image script

I don't remember who uses cpio but I remember that was needed as well

The apt-get update in the prefix makes docker re-run the apt-get update everytime, so that the apt cache is not obsolete when downloading new packages